### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See also http://en.wikipedia.org/wiki/Libfixmath.
 Works on AVR (Uno, etc) and ARM (Due, etc) based Arduinos.
 
 Benchmarks (Fix16_benchmark.ino example)
-
+```
 Arduino Due fix16_t vs double Benchmark (time in micro seconds):
 Op      double	  fixpt	  speed improvement fixpt over double
 Mult    372545	  97631	  381.58%
@@ -16,7 +16,9 @@ Div     1335860   203392	656.79%
 Add     457899	  14830	  3087.65%
 Sub     456773	  37275	  1225.41%
 Sqrt    14453     2842	  508.55%
+```
 
+```
 Arduino Due fix16_t vs float Benchmark (time in micro seconds):
 Op      float	    fixpt	  speed improvement fixpt over float
 Mult    304898	  103902	293.45%
@@ -24,5 +26,5 @@ Div     640075	  206859	309.43%
 Add     356009	  22301	  1596.38%
 Sub     361209	  39842	  906.60%
 Sqrt    14750	    2662	  554.09%
-
+```
 Released under MIT License.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ See also http://en.wikipedia.org/wiki/Libfixmath.
 
 Works on AVR (Uno, etc) and ARM (Due, etc) based Arduinos.
 
+PS: The examples may not compile, only Fix16_benchmark was tested and fixed from the original repository.
+
 Benchmarks (Fix16_benchmark.ino example)
 ```
 Arduino Due fix16_t vs double Benchmark (time in micro seconds):

--- a/README.md
+++ b/README.md
@@ -5,4 +5,24 @@ Fixed point (16.16 & 8.8) library for Arduino to replace resource hungry float/d
 Implementation based on libfixmath (https://code.google.com/p/libfixmath).
 See also http://en.wikipedia.org/wiki/Libfixmath.
 
+Works on AVR (Uno, etc) and ARM (Due, etc) based Arduinos.
+
+Benchmarks (Fix16_benchmark.ino example)
+
+Arduino Due fix16_t vs double Benchmark (time in micro seconds):
+Op      double	  fixpt	  speed improvement fixpt over double
+Mult    372545	  97631	  381.58%
+Div     1335860   203392	656.79%
+Add     457899	  14830	  3087.65%
+Sub     456773	  37275	  1225.41%
+Sqrt    14453     2842	  508.55%
+
+Arduino Due fix16_t vs float Benchmark (time in micro seconds):
+Op      float	    fixpt	  speed improvement fixpt over float
+Mult    304898	  103902	293.45%
+Div     640075	  206859	309.43%
+Add     356009	  22301	  1596.38%
+Sub     361209	  39842	  906.60%
+Sqrt    14750	    2662	  554.09%
+
 Released under MIT License.

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ Works on AVR (Uno, etc) and ARM (Due, etc) based Arduinos.
 Benchmarks (Fix16_benchmark.ino example)
 ```
 Arduino Due fix16_t vs double Benchmark (time in micro seconds):
-Op      double	  fixpt	  speed improvement fixpt over double
-Mult    372545	  97631	  381.58%
+Op      double	  fixpt	    speed improvement fixpt over double
+Mult    372545	  97631	    381.58%
 Div     1335860   203392	656.79%
-Add     457899	  14830	  3087.65%
-Sub     456773	  37275	  1225.41%
-Sqrt    14453     2842	  508.55%
+Add     457899	  14830	    3087.65%
+Sub     456773	  37275	    1225.41%
+Sqrt    14453     2842	    508.55%
 ```
 
 ```
 Arduino Due fix16_t vs float Benchmark (time in micro seconds):
-Op      float	    fixpt	  speed improvement fixpt over float
+Op      float	    fixpt	speed improvement fixpt over float
 Mult    304898	  103902	293.45%
 Div     640075	  206859	309.43%
-Add     356009	  22301	  1596.38%
-Sub     361209	  39842	  906.60%
-Sqrt    14750	    2662	  554.09%
+Add     356009	  22301	    1596.38%
+Sub     361209	  39842	    906.60%
+Sqrt    14750	    2662	 554.09%
 ```
 Released under MIT License.

--- a/examples/Fix16_benchmark/Fix16_benchmark.ino
+++ b/examples/Fix16_benchmark/Fix16_benchmark.ino
@@ -1,18 +1,8 @@
-#define NO_DOUBLE
-#define NO_FIX16
-
-#if !defined(NO_DOUBLE) && !defined(NO_FIX16)
 #include <stdio.h>
-#endif
-
-#ifndef NO_FIX16
 #include <fix16.h>
-#endif
-#ifndef NO_DOUBLE
 #include <math.h>
-#endif
 
-#define NUM_RUNS   (5)
+#define NUM_RUNS   (10)
 
 #define COMMENT(x) Serial.println(F("\n----" x "----"));
 
@@ -81,7 +71,7 @@ template<typename T> void test_divTestcases( void )
       T a = testcases[i];
       T b = testcases[j];
       // We don't require a solution for /0 :)
-      if (b == T(0)) continue;
+      if (b == T((int16_t)0)) continue;
       f = a / b;
     }
   }
@@ -115,20 +105,17 @@ template<typename T> void test_subTestcases( void )
   }
 }
 
-#ifndef NO_FIX16
 void test_sqrtTestcasesFix16( void )
 {
   unsigned int i;
   for (i = 0; i < TESTCASES_COUNT; i++)
   {
     Fix16 a = testcases[i];
-    if (a < Fix16(0)) continue;
+    if (a < (int32_t)0) continue;
     f = a.sqrt();
   }
 }
-#endif
 
-#ifndef NO_DOUBLE
 void test_sqrtTestcasesDouble( void )
 {
   unsigned int i;
@@ -139,7 +126,6 @@ void test_sqrtTestcasesDouble( void )
     f = sqrt(a);
   }
 }
-#endif
 
 #define TIMED_EXEC(func,delta,runs)  \
 {                                    \
@@ -151,8 +137,11 @@ void test_sqrtTestcasesDouble( void )
 
 void setup()
 {
-#if !defined(NO_DOUBLE) && !defined(NO_FIX16)
   Serial.begin(115200);
+  while(!Serial.available()){
+    Serial.println("Enter any key to begin");
+    delay(1000);
+  }
 
   COMMENT("Running testcases for multiplication");
   unsigned long time_Fix16Mult, time_doubleMult;
@@ -193,23 +182,6 @@ void setup()
   Serial.print("Sqrt    "); Serial.print(time_doubleSqrt); Serial.print("\t"); Serial.print(time_Fix16Sqrt); Serial.print("\t"); Serial.print(incr_Sqrt); Serial.println("%");
 
   COMMENT("Test finished");
-#endif
-
-#if defined(NO_DOUBLE) && !defined(NO_FIX16)
-  test_multTestcases<Fix16>();
-  test_divTestcases<Fix16>();
-  test_addTestcases<Fix16>();
-  test_subTestcases<Fix16>();
-  test_sqrtTestcasesFix16();
-#endif
-
-#if !defined(NO_DOUBLE) && defined(NO_FIX16)
-  test_multTestcases<double>();
-  test_divTestcases<double>();
-  test_addTestcases<double>();
-  test_subTestcases<double>();
-  test_sqrtTestcasesDouble();
-#endif
 
   while (1) {};
 }

--- a/examples/Fix16_benchmark/Fix16_benchmark.ino
+++ b/examples/Fix16_benchmark/Fix16_benchmark.ino
@@ -2,7 +2,7 @@
 #include <fix16.h>
 #include <math.h>
 
-#define NUM_RUNS   (10)
+#define NUM_RUNS   5
 
 #define COMMENT(x) Serial.println(F("\n----" x "----"));
 

--- a/libfixmath_conf.h
+++ b/libfixmath_conf.h
@@ -1,15 +1,25 @@
 #ifndef _LIBFIXMATH_CONF_H
 #define _LIBFIXMATH_CONF_H
 
-#ifdef ARDUINO_ARCH_AVR
-// ARDUINO_ARCH_AVR might not be the optimum define to check on,
-// but nothing else is available...
+#if defined(__arm__) 
+
+//#define FIXMATH_NO_64BIT
+//#define FIXMATH_OPTIMIZE_8BIT
+//#define FIXMATH_NO_CACHE
+#define FIXMATH_NO_OVERFLOW
+//#define FIXMATH_NO_ROUNDING
+
+#elif defined(__AVR__) 
+
 // AVR Architecture is 8bit & limited in memory
 #define FIXMATH_NO_64BIT
 #define FIXMATH_OPTIMIZE_8BIT
 #define FIXMATH_NO_CACHE
-//#define FIXMATH_NO_OVERFLOW
+#define FIXMATH_NO_OVERFLOW
 //#define FIXMATH_NO_ROUNDING
+
+#else
+#error Architecture or board not supported.
 #endif
 
 #endif


### PR DESCRIPTION
Fixed the Fix16_benchmark not compiling: there was some ambiguity in the code when calling the Fix16 class functions, it requires to cast constants ("0" becomes "(uint32_t)0"), nothing complicated.

Changed libfixmath_conf.h to allow different configurations for both ARM and AVR architectures.
